### PR TITLE
Hole average stats now reflect recent round performance.

### DIFF
--- a/pages/styles/Stats.scss
+++ b/pages/styles/Stats.scss
@@ -9,3 +9,11 @@
 .best-score {
   background-color: yellow;
 }
+
+.trending-up {
+  color: #ffcccc;
+}
+
+.trending-down {
+  color: #ccffdd;
+}


### PR DESCRIPTION
This is accomplished by having the data generator record an additional stat per player/hole that only reflects the performance in the last X holes. The client then has access to all time data and this recent metric. The data generation change is so slight, it should not add any additional maintenance cost.

This change allows us see how folks are doing in their latest rounds, instead of displayed "career averages". This also allows us to show arrows signifying if players are trending up or down on given holes when compared to their lifetime average.

There are minimal changes here to the data generation. I agree with most that the majority/all of the data generation should just happen on the fly in the web page instead of statically generating it all upfront. That would be a great change for someone to make separate of this change.