### PR TITLE
Add support for skins (and some bonuses)

### DIFF
--- a/src/data/getAllData.js
+++ b/src/data/getAllData.js
@@ -1,11 +1,17 @@
 import { google } from 'googleapis';
+import { first, sum, tail, zipObject } from 'lodash';
 
 import { getPlayerInfo } from './utils';
 
 const { GOOGLE_SHEETS_API_KEY, SPREADSHEET_ID } = process.env;
 
-const CELL_RANGE = 'A3:J';
+const CELL_RANGE = 'A1:J';
 const RANGE_DATE_REGEX = new RegExp(`'(.*)T.*'!${CELL_RANGE}`, 'i');
+const DEFAULT_COURSE = 'Mariners Point';
+const DEFAULT_HOLE_PAR = 3;
+const PAR_PLAYER_NAME = 'PAR';
+const SKINS_TOKEN = '(s)';
+const ROUND_SKIN_TOKEN = '(r)';
 
 // Initialize Sheets API.
 const SheetsAPI = google.sheets({
@@ -23,7 +29,12 @@ const options = {
  *   id: string,
  *   date: string,
  *   location:string,
- *   players: string[]
+ *   holes: number[],
+ *   pars: Object<string, number>,
+ *   parTotal: number,
+ *   players: string[],
+ *   skinsPlayers: string[],
+ *   roundSkinsPlayers: string[],
  * }} Round
  */
 
@@ -33,9 +44,75 @@ const options = {
  *   player: string,
  *   round: string,
  *   hole: number,
+ *   par: number,
  *   score: number,
  * }} Score
  */
+
+/**
+ *
+ * @param {{ range: string, values: string[][] }} valueRange
+ * @returns {{ round: Round, roundScores: Score[] }}
+ */
+function parseRange({ range, values }) {
+  const roundScores = [];
+  const players = [];
+  const skinsPlayers = [];
+  const roundSkinsPlayers = [];
+
+  // Pull the date from the sheet title (embedded in the range)
+  const [, date] = RANGE_DATE_REGEX.exec(range);
+  const roundId = date;
+
+  // Pull the location from the first row
+  const [courseRow, holesRow, ...scoreRows] = values;
+  const location = first(courseRow) || DEFAULT_COURSE;
+
+  // If there's row representing the par values for each hole, grab it
+  const sheetHasParRow = scoreRows[0][0].includes(PAR_PLAYER_NAME);
+  let pars = Array(9).fill(DEFAULT_HOLE_PAR);
+  if (sheetHasParRow) {
+    const parRow = scoreRows.shift();
+    pars = tail(parRow).map((par) => parseInt(par, 10));
+  }
+  const holes = tail(holesRow).map((hole) => parseInt(hole, 10));
+
+  scoreRows.forEach((scoreRow) => {
+    const [playerKey, ...playerScores] = scoreRow;
+    const playerId = getPlayerInfo(playerKey).id;
+    players.push(playerId);
+    if (playerKey.includes(SKINS_TOKEN)) {
+      skinsPlayers.push(playerId);
+    }
+    if (playerKey.includes(ROUND_SKIN_TOKEN)) {
+      roundSkinsPlayers.push(playerId);
+    }
+
+    playerScores.forEach((score, idx) => {
+      roundScores.push({
+        player: playerId,
+        round: roundId,
+        hole: holes[idx],
+        par: pars[idx],
+        score: parseInt(score, 10),
+      });
+    });
+  });
+
+  const round = {
+    id: roundId,
+    date,
+    location,
+    holes,
+    pars: zipObject(holes, pars),
+    parTotal: sum(pars),
+    players,
+    skinsPlayers,
+    roundSkinsPlayers,
+  };
+
+  return { round, roundScores };
+}
 
 /**
  * @returns {Promise<{ rounds: Round[], scores: Score[] }>}
@@ -54,32 +131,10 @@ export default async function getAllData() {
   // Parse the sheet data into rounds and scores
   const rounds = [];
   const scores = [];
-  data.valueRanges.forEach(({ range, values }) => {
-    const [, date] = RANGE_DATE_REGEX.exec(range);
-    const roundId = date;
-    const roundPlayers = [];
-
-    values.forEach((row) => {
-      const playerKey = row.shift();
-      const { id: playerId } = getPlayerInfo(playerKey);
-      roundPlayers.push(playerId);
-
-      row.forEach((score, idx) => {
-        scores.push({
-          player: playerId,
-          round: roundId,
-          hole: idx + 1,
-          score: parseInt(score, 10),
-        });
-      });
-    });
-
-    rounds.push({
-      id: roundId,
-      date,
-      players: roundPlayers,
-      location: 'Mariner\'s Point',
-    });
+  data.valueRanges.forEach((valueRange) => {
+    const { round, roundScores } = parseRange(valueRange);
+    rounds.push(round);
+    scores.push(...roundScores);
   });
 
   return { rounds, scores };

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -242,15 +242,15 @@ const StatsPage = ({ rounds, topRounds, globalHoleAvgs, playerStats }) => {
  * @typedef {{
  *   rounds: Round[],
  *   topRounds: PlayerRoundSummary[],
- *   globalHoleAvgs: Object<number, number>,
+ *   globalHoleAvgs: Object<string, number>,
  *   playerStats: {
  *     id: string,
  *     name: string,
  *     roundAvg: number,
  *     roundsPlayed: number,
  *     roundsPlayedPercentage: number,
- *     holeAvgs: Object<number, number>,
- *     recentHoleAvgs: Object<number, number>,
+ *     holeAvgs: Object<string, number>,
+ *     recentHoleAvgs: Object<string, number>,
  *   },
  * }} props
  *


### PR DESCRIPTION
Closes #15

This diff adds support for skins into the system. That means a marker in the spreadsheet to note that a player played skins ("(s)"), storing this data in round data, and rendering it out when show the results of a single round.

While updated the spreadsheet parsing, I added a couple features.
- Cell A1 can now be used for the name of the course.
- There's an optional row that can be added below the list of holes that will list the par values for those holes.
- The individual score objects now include the par value for the hole.
These changes are a big step towards #13. In fact, any 9 hole course should be supported now. We'd want to do the additional step of making the UI separate stats for different course before adding data from other places.