### PR TITLE
Add round score visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "classnames": "^2.2.6",
+    "d3": "^6.2.0",
     "googleapis": "^61.0.0",
     "lodash": "^4.17.20",
     "next": "^9.5.4",

--- a/src/components/Chart/Axis.js
+++ b/src/components/Chart/Axis.js
@@ -1,0 +1,21 @@
+import * as d3 from 'd3';
+import React, { useEffect, useRef } from 'react';
+
+const Axis = ({ axis, ...props }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      d3.select(containerRef.current).call(axis);
+    }
+  }, [axis]);
+
+  return (
+    <g
+      {...props}
+      ref={containerRef}
+    />
+  );
+};
+
+export default Axis;

--- a/src/components/Chart/Line.js
+++ b/src/components/Chart/Line.js
@@ -1,0 +1,19 @@
+import * as d3 from 'd3';
+import React from 'react';
+
+const Line = ({ data, x, y, ...props }) => {
+  const line = d3
+    .line()
+    .x(x)
+    .y(y);
+
+  return (
+    <path
+      {...props}
+      d={line(data)}
+      fill="none"
+    />
+  );
+};
+
+export default Line;

--- a/src/components/Chart/RoundsChart.js
+++ b/src/components/Chart/RoundsChart.js
@@ -1,0 +1,162 @@
+import cx from 'classnames';
+import * as d3 from 'd3';
+import { groupBy } from 'lodash';
+import React, { useEffect, useRef, useState } from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+import Axis from './Axis';
+import Line from './Line';
+
+import { getPlayerInfo } from '../../data/utils';
+
+import styles from './styles/RoundsChart.module.scss';
+
+const useResizeObserver = (
+  containerRef,
+  initialSize = { height: 0, width: 0 }
+) => {
+  const [size, setSize] = useState(initialSize);
+
+  useEffect(() => {
+    const containerElem = containerRef.current;
+
+    if (!containerElem) {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      setSize({
+        height: containerElem.clientHeight,
+        width: containerElem.clientWidth,
+      });
+    });
+
+    observer.observe(containerElem);
+
+    return () => observer.unobserve(containerElem);
+  }, [containerRef]);
+
+  return size;
+};
+
+const translate = (x, y) => `translate(${x}, ${y})`;
+
+const COLORS = [
+  '#23171b',
+  '#3987f9',
+  '#2ee5ae',
+  '#95fb51',
+  '#feb927',
+  '#e54813',
+  '#900c00',
+];
+const HEIGHT = 360;
+const MARGIN = {
+  bottom: 24,
+  left: 8,
+  right: 8,
+  top: 16,
+};
+
+const parseTime = d3.timeParse('%Y-%m-%d');
+
+const RoundsChart = ({ data }) => {
+  const ref = useRef(null);
+  const { height, width } = useResizeObserver(ref);
+
+  const innerHeight = height - MARGIN.top - MARGIN.bottom;
+  const innerWidth = width - MARGIN.left - MARGIN.right;
+
+  const players = groupBy(data, 'player');
+
+  const xScale = d3.scaleTime()
+    .domain(d3.extent(data, (d) => parseTime(d.round)))
+    .rangeRound([0, innerWidth]);
+
+  const yScale = d3.scaleLinear()
+    .domain([
+      d3.min(data, (d) => d.total) - 1,
+      d3.max(data, (d) => d.total),
+    ])
+    .rangeRound([innerHeight, 0]);
+
+  const xAxis = d3
+    .axisBottom(xScale)
+    .tickFormat((date) => (
+      d3.timeYear(date) < date ?
+        d3.timeFormat('%b')(date) :
+        d3.timeFormat('%Y')(date)
+    ))
+    .tickSize(12);
+
+  const yAxis = d3
+    .axisLeft(yScale)
+    .ticks(5)
+    .tickSize(3);
+
+  return (
+    <div className={styles.container} ref={ref}>
+      <svg
+        height={HEIGHT}
+        width={width}>
+        <g transform={translate(MARGIN.left, MARGIN.top)}>
+          <Axis
+            axis={xAxis}
+            className={cx(styles.axis, styles.xAxis)}
+            transform={translate(0, innerHeight)}
+          />
+          <Axis
+            axis={yAxis}
+            className={cx(styles.axis, styles.yAxis)}
+          />
+          {Object.keys(players).map((id, idx) => (
+            <React.Fragment key={id}>
+              <Line
+                data={players[id]}
+                stroke={COLORS[idx]}
+                x={(d) => xScale(parseTime(d.round))}
+                y={(d) => yScale(d.total)}
+              />
+              {players[id].map(({ round, total }) => {
+                const date = (new Date(round)).toLocaleDateString(undefined, {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                });
+
+                // Don't display the player's name on their profile page.
+                const name = Object.keys(players).length > 1 ?
+                  <React.Fragment>
+                    {getPlayerInfo(id).name}<br />
+                  </React.Fragment> :
+                  null;
+
+                return (
+                  <OverlayTrigger
+                    key={`${id}-${round}`}
+                    overlay={
+                      <Tooltip>
+                        {date}<br />
+                        {name}
+                        {total}
+                      </Tooltip>
+                    }
+                    placement="top">
+                    <circle
+                      cx={xScale(parseTime(round))}
+                      cy={yScale(total)}
+                      fill={COLORS[idx]}
+                      r={4}
+                    />
+                  </OverlayTrigger>
+                );
+              })}
+            </React.Fragment>
+          ))}
+        </g>
+      </svg>
+    </div>
+  );
+};
+
+export default RoundsChart;

--- a/src/components/Chart/styles/RoundsChart.module.scss
+++ b/src/components/Chart/styles/RoundsChart.module.scss
@@ -1,0 +1,35 @@
+.container {
+  margin-bottom: 30px;
+}
+
+.axis {
+  path, line {
+    fill: none;
+    stroke: #dee2e6; // Match table border style
+    shape-rendering: crispEdges;
+  }
+
+  .domain {
+    stroke: none;
+  }
+}
+
+.xAxis {
+  text {
+    text-anchor: start;
+    transform: translate(3px, -10px);
+  }
+}
+
+.yAxis {
+  text {
+    text-anchor: start;
+    transform: translate(10px, -8px);
+  }
+
+  &-background {
+    text {
+      display: none;
+    }
+  }
+}

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -50,7 +50,7 @@ export function getAvg(numerator, denominator, precision = 1) {
  * @param {Score[]} scores
  * @returns {PlayerRoundSummary[]}
  */
-function getPlayerRoundSummaries(scores) {
+export function getPlayerRoundSummaries(scores) {
   const groupedScores = groupBy(
     scores,
     ({ player, round }) => `${player}-${round}`

--- a/src/pages/player/[id].js
+++ b/src/pages/player/[id].js
@@ -1,22 +1,25 @@
 import { filter, find, some } from 'lodash';
 import React from 'react';
 
-import getAllData from '../../data/getAllData';
-import { getTopRounds } from '../../data/utils';
-import Layout from '../../components/Layout';
 import BestRoundsTable from '../../components/BestRoundsTable';
+import Layout from '../../components/Layout';
+import ProfileImage from '../../components/ProfileImage';
+import RoundsChart from '../../components/Chart/RoundsChart';
+import RoundTable from '../../components/RoundTable';
+
+import getAllData from '../../data/getAllData';
+import { getPlayerRoundSummaries, getTopRounds } from '../../data/utils';
 
 import { PLAYERS } from '../../constants';
-import RoundTable from '../../components/RoundTable';
-import ProfileImage from '../../components/ProfileImage';
 
 const TOP_ROUNDS = 5;
 
 export default function PlayerPage({
   playerInfo,
-  topRounds,
+  roundsSummary,
   roundsWithPlayer,
   scoresWithPlayer,
+  topRounds,
 }) {
   const { name, fbId } = playerInfo;
 
@@ -28,7 +31,7 @@ export default function PlayerPage({
       </h1>
       <h3>Best Rounds</h3>
       <BestRoundsTable topRounds={topRounds} rounds={roundsWithPlayer} />
-
+      <RoundsChart data={roundsSummary} />
       {roundsWithPlayer.map((round) => (
         <RoundTable key={round.id} round={round} scores={scoresWithPlayer} />
       ))}
@@ -53,9 +56,10 @@ export async function getStaticProps({ params: { id } }) {
   return {
     props: {
       playerInfo,
-      topRounds,
+      roundsSummary: getPlayerRoundSummaries(playerScores),
       roundsWithPlayer,
       scoresWithPlayer,
+      topRounds,
     },
     revalidate: 30,
   };

--- a/src/pages/rounds.js
+++ b/src/pages/rounds.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { orderBy } from 'lodash';
 
 import Layout from '../components/Layout';
-import getAllData from '../data/getAllData';
-
+import RoundsChart from '../components/Chart/RoundsChart';
 import RoundTable from '../components/RoundTable';
+
+import getAllData from '../data/getAllData';
+import { getPlayerRoundSummaries } from '../data/utils';
 
 /**
  * @typedef {import('../data/getAllData').Round} Round
@@ -14,6 +16,7 @@ import RoundTable from '../components/RoundTable';
  */
 const RoundsPage = ({ rounds, scores }) => (
   <Layout title="Rounds">
+    <RoundsChart data={getPlayerRoundSummaries(scores)} />
     {rounds.map((round) => (
       <RoundTable key={round.id} round={round} scores={scores} />
     ))}

--- a/src/pages/stats.js
+++ b/src/pages/stats.js
@@ -13,9 +13,10 @@ import {
 import React, { useCallback, useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
+import BestRoundsTable from '../components/BestRoundsTable';
 import Layout from '../components/Layout';
 import Table from '../components/Table';
-import BestRoundsTable from '../components/BestRoundsTable';
+
 import getAllData from '../data/getAllData';
 
 import { HOLES, PAR, PLAYERS } from '../constants';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1864,7 +1864,7 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
 
-commander@^2.20.0:
+commander@2, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
 
@@ -2102,6 +2102,246 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
+d3-array@2, d3-array@>=2.5, d3-array@^2.3.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
+  integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==
+
+d3-axis@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-2.0.0.tgz#40aebb65626ffe6d95e9441fbf9194274b328a8b"
+  integrity sha512-9nzB0uePtb+u9+dWir+HTuEAKJOEUYJoEwbJPsZ1B4K3iZUgzJcSENQ05Nj7S4CIfbZZ8/jQGoUzGKFznBhiiQ==
+
+d3-brush@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-2.1.0.tgz#adadfbb104e8937af142e9a6e2028326f0471065"
+  integrity sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-drag "2"
+    d3-interpolate "1 - 2"
+    d3-selection "2"
+    d3-transition "2"
+
+d3-chord@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-2.0.0.tgz#32491b5665391180560f738e5c1ccd1e3c47ebae"
+  integrity sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==
+  dependencies:
+    d3-path "1 - 2"
+
+"d3-color@1 - 2", d3-color@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
+
+d3-contour@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-2.0.0.tgz#80ee834988563e3bea9d99ddde72c0f8c089ea40"
+  integrity sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==
+  dependencies:
+    d3-array "2"
+
+d3-delaunay@5:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/d3-delaunay/-/d3-delaunay-5.3.0.tgz#b47f05c38f854a4e7b3cea80e0bb12e57398772d"
+  integrity sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==
+  dependencies:
+    delaunator "4"
+
+"d3-dispatch@1 - 2", d3-dispatch@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-2.0.0.tgz#8a18e16f76dd3fcaef42163c97b926aa9b55e7cf"
+  integrity sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==
+
+d3-drag@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-2.0.0.tgz#9eaf046ce9ed1c25c88661911c1d5a4d8eb7ea6d"
+  integrity sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-selection "2"
+
+"d3-dsv@1 - 2", d3-dsv@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-2.0.0.tgz#b37b194b6df42da513a120d913ad1be22b5fe7c5"
+  integrity sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+"d3-ease@1 - 2", d3-ease@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-2.0.0.tgz#fd1762bfca00dae4bacea504b1d628ff290ac563"
+  integrity sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==
+
+d3-fetch@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-2.0.0.tgz#ecd7ef2128d9847a3b41b548fec80918d645c064"
+  integrity sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==
+  dependencies:
+    d3-dsv "1 - 2"
+
+d3-force@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-2.1.1.tgz#f20ccbf1e6c9e80add1926f09b51f686a8bc0937"
+  integrity sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-quadtree "1 - 2"
+    d3-timer "1 - 2"
+
+"d3-format@1 - 2", d3-format@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-2.0.0.tgz#a10bcc0f986c372b729ba447382413aabf5b0767"
+  integrity sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==
+
+d3-geo@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-2.0.1.tgz#2437fdfed3fe3aba2812bd8f30609cac83a7ee39"
+  integrity sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==
+  dependencies:
+    d3-array ">=2.5"
+
+d3-hierarchy@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz#dab88a58ca3e7a1bc6cab390e89667fcc6d20218"
+  integrity sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==
+
+"d3-interpolate@1 - 2", "d3-interpolate@1.2.0 - 2", d3-interpolate@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
+  dependencies:
+    d3-color "1 - 2"
+
+"d3-path@1 - 2", d3-path@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-2.0.0.tgz#55d86ac131a0548adae241eebfb56b4582dd09d8"
+  integrity sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==
+
+d3-polygon@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-2.0.0.tgz#13608ef042fbec625ba1598327564f03c0396d8e"
+  integrity sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ==
+
+"d3-quadtree@1 - 2", d3-quadtree@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-2.0.0.tgz#edbad045cef88701f6fee3aee8e93fb332d30f9d"
+  integrity sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw==
+
+d3-random@2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-2.2.2.tgz#5eebd209ef4e45a2b362b019c1fb21c2c98cbb6e"
+  integrity sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw==
+
+d3-scale-chromatic@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz#c13f3af86685ff91323dc2f0ebd2dabbd72d8bab"
+  integrity sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==
+  dependencies:
+    d3-color "1 - 2"
+    d3-interpolate "1 - 2"
+
+d3-scale@3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-3.2.3.tgz#be380f57f1f61d4ff2e6cbb65a40593a51649cfd"
+  integrity sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==
+  dependencies:
+    d3-array "^2.3.0"
+    d3-format "1 - 2"
+    d3-interpolate "1.2.0 - 2"
+    d3-time "1 - 2"
+    d3-time-format "2 - 3"
+
+d3-selection@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-2.0.0.tgz#94a11638ea2141b7565f883780dabc7ef6a61066"
+  integrity sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==
+
+d3-shape@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-2.0.0.tgz#2331b62fa784a2a1daac47a7233cfd69301381fd"
+  integrity sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==
+  dependencies:
+    d3-path "1 - 2"
+
+"d3-time-format@2 - 3", d3-time-format@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-3.0.0.tgz#df8056c83659e01f20ac5da5fdeae7c08d5f1bb6"
+  integrity sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==
+  dependencies:
+    d3-time "1 - 2"
+
+"d3-time@1 - 2", d3-time@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
+  integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
+
+"d3-timer@1 - 2", d3-timer@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-2.0.0.tgz#055edb1d170cfe31ab2da8968deee940b56623e6"
+  integrity sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==
+
+d3-transition@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-2.0.0.tgz#366ef70c22ef88d1e34105f507516991a291c94c"
+  integrity sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==
+  dependencies:
+    d3-color "1 - 2"
+    d3-dispatch "1 - 2"
+    d3-ease "1 - 2"
+    d3-interpolate "1 - 2"
+    d3-timer "1 - 2"
+
+d3-zoom@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-2.0.0.tgz#f04d0afd05518becce879d04709c47ecd93fba54"
+  integrity sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==
+  dependencies:
+    d3-dispatch "1 - 2"
+    d3-drag "2"
+    d3-interpolate "1 - 2"
+    d3-selection "2"
+    d3-transition "2"
+
+d3@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-6.2.0.tgz#f19b0ecb16ca4ad2171ce8b37c63247e71c6f01d"
+  integrity sha512-aH+kx55J8vRBh4K4k9GN4EbNO3QnZsXy4XBfrnr4fL2gQuszUAPQU3fV2oObO2iSpreRH/bG/wfvO+hDu2+e9w==
+  dependencies:
+    d3-array "2"
+    d3-axis "2"
+    d3-brush "2"
+    d3-chord "2"
+    d3-color "2"
+    d3-contour "2"
+    d3-delaunay "5"
+    d3-dispatch "2"
+    d3-drag "2"
+    d3-dsv "2"
+    d3-ease "2"
+    d3-fetch "2"
+    d3-force "2"
+    d3-format "2"
+    d3-geo "2"
+    d3-hierarchy "2"
+    d3-interpolate "2"
+    d3-path "2"
+    d3-polygon "2"
+    d3-quadtree "2"
+    d3-random "2"
+    d3-scale "3"
+    d3-scale-chromatic "2"
+    d3-selection "2"
+    d3-shape "2"
+    d3-time "2"
+    d3-time-format "3"
+    d3-timer "2"
+    d3-transition "2"
+    d3-zoom "2"
+
 d@1, d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
@@ -2167,6 +2407,11 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+delaunator@4:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
+  integrity sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -3094,6 +3339,13 @@ husky@^4.2.0:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+iconv-lite@0.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -4767,6 +5019,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
+
 rxjs@^6.6.2:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
@@ -4787,7 +5044,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 


### PR DESCRIPTION
Add a line graph showing players' round scores over time. This is an initial version; there are several things we could add, most notably some kind of interactive legend that allows users to modify which players show up.

![image](https://user-images.githubusercontent.com/2978513/96226139-096a7b00-0f47-11eb-8f30-b0718752e16b.png)
![image](https://user-images.githubusercontent.com/2978513/96226101-fc4d8c00-0f46-11eb-9ecf-6236493f7778.png)

