### PR TITLE
Updates to rounds chart

### DIFF
--- a/src/components/Chart/RoundsChart.js
+++ b/src/components/Chart/RoundsChart.js
@@ -42,15 +42,7 @@ const useResizeObserver = (
 
 const translate = (x, y) => `translate(${x}, ${y})`;
 
-const COLORS = [
-  '#23171b',
-  '#3987f9',
-  '#2ee5ae',
-  '#95fb51',
-  '#feb927',
-  '#e54813',
-  '#900c00',
-];
+const COLORS = d3.schemeCategory10;
 const HEIGHT = 360;
 const MARGIN = {
   bottom: 24,

--- a/src/components/Chart/RoundsChart.js
+++ b/src/components/Chart/RoundsChart.js
@@ -1,14 +1,15 @@
 import cx from 'classnames';
 import * as d3 from 'd3';
+import { parseISO, format } from 'date-fns';
 import groupBy from 'lodash/groupBy';
 import React, { useEffect, useRef, useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
-import { parseISO, format } from 'date-fns';
 
 import Axis from './Axis';
 import Line from './Line';
 
 import { getPlayerInfo } from '../../data/utils';
+import { PAR } from '../../constants';
 
 import styles from './styles/RoundsChart.module.scss';
 
@@ -129,7 +130,7 @@ const RoundsChart = ({ data }) => {
                       <Tooltip>
                         {date}<br />
                         {name}
-                        {total}
+                        {total} (+{total - PAR})
                       </Tooltip>
                     }
                     placement="top">

--- a/src/pages/rounds.js
+++ b/src/pages/rounds.js
@@ -1,12 +1,14 @@
-import React from 'react';
+import groupBy from 'lodash/groupBy';
 import orderBy from 'lodash/orderBy';
+import React, { useState } from 'react';
+import { Form } from 'react-bootstrap';
 
 import Layout from '../components/Layout';
 import RoundsChart from '../components/Chart/RoundsChart';
 import RoundTable from '../components/RoundTable';
 
 import getAllData from '../data/getAllData';
-import { getPlayerRoundSummaries } from '../data/utils';
+import { getPlayerInfo, getPlayerRoundSummaries } from '../data/utils';
 
 /**
  * @typedef {import('../data/getAllData').Round} Round
@@ -14,14 +16,45 @@ import { getPlayerRoundSummaries } from '../data/utils';
  *
  * @param {{ rounds: Round[], scores: Score[] }} props
  */
-const RoundsPage = ({ rounds, scores }) => (
-  <Layout title="Rounds">
-    <RoundsChart data={getPlayerRoundSummaries(scores)} />
-    {rounds.map((round) => (
-      <RoundTable key={round.id} round={round} scores={scores} />
-    ))}
-  </Layout>
-);
+const RoundsPage = ({ rounds, scores }) => {
+  const data = getPlayerRoundSummaries(scores);
+  const players = Object.keys(groupBy(data, 'player'));
+
+  const [selectedPlayers, setSelectedPlayers] = useState(players);
+  const filteredData = data.filter(({ player }) => (
+    selectedPlayers.includes(player)
+  ));
+
+  return (
+    <Layout title="Rounds">
+      <RoundsChart data={filteredData} />
+      <div style={{ margin: '-20px 0 30px' }}>
+        {players.map((id, idx) => {
+          const checked = selectedPlayers.includes(id);
+          return (
+            <Form.Check
+              checked={checked}
+              id={id}
+              inline
+              key={id}
+              label={getPlayerInfo(id).name}
+              onChange={() => {
+                const selected = checked ?
+                  selectedPlayers.filter((pid) => pid !== id) :
+                  selectedPlayers.concat([id]);
+
+                setSelectedPlayers(selected);
+              }}
+            />
+          );
+        })}
+      </div>
+      {rounds.map((round) => (
+        <RoundTable key={round.id} round={round} scores={scores} />
+      ))}
+    </Layout>
+  );
+};
 
 export async function getStaticProps() {
   const { rounds, scores } = await getAllData();


### PR DESCRIPTION
- Use different color scale to account for more players.
- Add checkboxes so we can add/remove players from chart
- Add shots above par to tooltip

![image](https://user-images.githubusercontent.com/2978513/97116828-21679a80-16bd-11eb-8605-9fcdd4bc340c.png)
